### PR TITLE
factor ray-operator-ubi out from ray-ubi

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -x -e
+
+# usage: build.sh <py-major> <py-minor> <full-ray-sha> <image-registry>
+# example:
+# ./build.sh 3 6 864956f81753884357e32840c13610dadf968341 quay.io/erikerlandson
+
+# eventually will replace ray sha with actual version when 2.x releases
+
+# intended to be run from top of the repo, for example:
+# cd /path/to/ray-ubi
+# ./build.sh
+
+# Note: if desired you should be able to replace 'podman' with 'docker'
+# as a drop-in replacement
+
+# On ubi-minimal, available python are currently 'python36' and 'python38'
+# The upstream nightly Ray wheel appears to not support python 3.8, so
+# practially speaking the only python supportable from both ubi-minimal
+# and ray is python 3.6, unless I modify the docker-file to install python
+# from some other source than micro-dnf
+
+# command line args
+export PY_MAJOR=$1
+export PY_MINOR=$2
+export RAY_SHA_FULL=$3
+export REGISTRY=$4
+
+# eventually this will be actual version, like 2.0.0
+export RAY_VERSION=${RAY_SHA_FULL:0:8}
+
+# ray cares about keeping major+minor python aligned so it is important to tag it that way
+export RAY_UBI_TAG="py-${PY_MAJOR}.${PY_MINOR}-ray-${RAY_VERSION}"
+
+# base image currently has to install ray from nightly wheel which uses SHA
+podman build --no-cache -t ${REGISTRY}/ray-ubi:${RAY_UBI_TAG} \
+       --build-arg PY_MAJOR=${PY_MAJOR} --build-arg PY_MINOR=${PY_MINOR} \
+       --build-arg RAY_SHA_FULL=${RAY_SHA_FULL} \
+       ./images/ray-ubi
+
+podman build --no-cache -t ${REGISTRY}/ray-operator-ubi:${RAY_UBI_TAG} \
+       --build-arg PY_MAJOR=${PY_MAJOR} --build-arg PY_MINOR=${PY_MINOR} \
+       --build-arg RAY_VERSION=${RAY_VERSION} \
+       ./images/ray-operator-ubi
+
+# a build for hypothetical ray-ml-ubi goes here.

--- a/images/ray-operator-ubi/Dockerfile
+++ b/images/ray-operator-ubi/Dockerfile
@@ -1,0 +1,41 @@
+# If you need these visible after the FROM, be sure to
+# add duplicate ARG declarations _after_ the FROM
+ARG PY_MAJOR
+ARG PY_MINOR
+ARG RAY_VERSION
+
+FROM quay.io/erikerlandson/ray-ubi:py-${PY_MAJOR}.${PY_MINOR}-ray-${RAY_VERSION}
+
+USER root:0
+
+# The autoscaler needs the kubectl binary to talk to the kube cluster API
+ENV OC_CLIENT_RELEASE=4.6.0-0.okd-2021-01-23-132511
+RUN echo \
+ && echo "install wget and tar" \
+ && microdnf install wget tar gzip \
+ && echo \
+ && echo "download and install the kubectl static binary" \
+ && cd /tmp \
+ && wget -nv https://github.com/openshift/okd/releases/download/${OC_CLIENT_RELEASE}/openshift-client-linux-${OC_CLIENT_RELEASE}.tar.gz \
+ && tar xzf openshift-client-linux-${OC_CLIENT_RELEASE}.tar.gz \
+ && mv kubectl /usr/bin \
+ && chmod a+rx /usr/bin/kubectl \
+ && echo \
+ && echo "clean up" \
+ && rm -rf /tmp/* \
+ && microdnf remove wget tar gzip \
+ && microdnf clean all
+
+# ray operator requires deps for autoscaler functionality
+RUN echo \
+ && echo "installing ray operator python deps" \
+ && cd /opt/ray \
+ && pipenv install \
+    kubernetes \
+    boto3==1.4.8 \
+ && rm -rf /tmp/* /root/.cache /root/.local \
+ && chown -R 9998:0 /opt/ray \
+ && chmod -R g+rwX /opt/ray
+
+# emulate anonymous uid
+USER 9999:0

--- a/images/ray-ubi/Dockerfile
+++ b/images/ray-ubi/Dockerfile
@@ -1,8 +1,18 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-WORKDIR /opt/ray
+ARG PY_MAJOR
+ARG PY_MINOR
+ARG RAY_SHA_FULL
 
-COPY Pipfile /opt/ray/
+USER root:0
+
+# Define an entrypoint that does proper signal handling
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+RUN chmod a+rx /tini
+ENTRYPOINT ["/tini", "--"]
+
+WORKDIR /opt/ray
 
 # environment for doing the pipenv install of the Pipfile
 # WORKON_HOME tells pipenv to put the virtualenv in same dir so
@@ -12,34 +22,49 @@ ENV LANG="C.UTF-8" \
     LC_CTYPE="C.UTF-8" \
     WORKON_HOME=/opt/ray \
     PIPENV_NOSPIN=1 \
-    OC_CLIENT_RELEASE=4.6.0-0.okd-2021-01-23-132511
+    PIPENV_DEFAULT_PYTHON_VERSION=${PY_MAJOR}.${PY_MINOR} \
+    PIPENV_NO_INHERIT=True \
+    RAY_WHEEL_URL=https://ray-wheels.s3-us-west-2.amazonaws.com/master/${RAY_SHA_FULL}/ray-2.0.0.dev0-cp${PY_MAJOR}${PY_MINOR}-cp${PY_MAJOR}${PY_MINOR}m-manylinux2014_x86_64.whl
 
-# I'm using python 3.6 specifically, as it works broadly
-# and the ODH spark-cluster images also use it.
+# Install requested python version (example: python36)
+# on ubi-minimal, available python are currently 'python36' and 'python38'
+# The upstream nightly Ray wheel appears to not support python 3.8, so
+# practially speaking the only python supportable from both ubi-minimal
+# and ray is python 3.6, unless I modify this to install python from some other
+# source than micro-dnf
 # 'which' is used by pipenv to locate a python interpreter to run
-RUN microdnf install python36 which wget tar gzip \
+# 'procps-ng' provides the 'uptime' command, which is invoked remotely by the
+# ray operator/autoscaler
+RUN echo \
+ && echo "installing OS package deps" \
+ && microdnf install python${PY_MAJOR}${PY_MINOR} which procps-ng \
  && microdnf clean all \
- && pip3 install pipenv \
  && echo \
- && echo "install the ray python environment" \
+ && echo "installing pipenv" \
+ && pip3 install pipenv
+
+# creating an empty `.bashrc` below, because ray currently has a
+# hard-coded assumption that `$HOME/.bashrc` exists. I am not setting
+# HOME in these docker-files to avoid confusion during image build,
+# but you should set HOME=/opt in your container yaml during deployment
+# see: https://github.com/ray-project/ray/issues/14155
+RUN echo \
+ && echo "installing the ray python environment" \
+ && mkdir -p /opt/ray \
  && cd /opt/ray \
- && pipenv --python 3.6 install \
+ && pipenv --python ${PY_MAJOR}.${PY_MINOR} install \
+    ${RAY_WHEEL_URL} \
+    cython==0.29.0 \
+    flatbuffers \
+    psutil \
+    $(if [ "$PY_MINOR" -lt "7" ]; then \
+        echo "dataclasses" ; \
+      fi) \
  # after the install, deleting .cache, .local and /tmp saves space \
  && rm -rf /tmp/* /root/.cache /root/.local \
  && chown -R 9998:0 /opt/ray \
- && chmod -R g+rwX /opt/ray \
- && echo \
- && echo "download and install the kubectl static binary" \
- && cd /tmp \
- && wget -nv https://github.com/openshift/okd/releases/download/${OC_CLIENT_RELEASE}/openshift-client-linux-${OC_CLIENT_RELEASE}.tar.gz \
- && tar xzf openshift-client-linux-${OC_CLIENT_RELEASE}.tar.gz \
- && mv kubectl /usr/bin \
- && chmod a+rx /usr/bin/kubectl \
- && rm -rf /tmp/* \
- && echo \
- && echo "clean up dnf packages" \
- && microdnf remove wget tar gzip \
- && microdnf clean all
+ && touch /opt/.bashrc \
+ && chmod -R g+rwX /opt
 
 # in the above, ray has been installed as a pipenv environment - if you want to run
 # ray on this image, a way to do this is:
@@ -51,13 +76,7 @@ RUN microdnf install python36 which wget tar gzip \
 # FROM <this image>
 # RUN cd /opt/ray && pipenv install ...
 
-# Define an entrypoint that does proper signal handling
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
-RUN chmod a+rx /tini
-ENTRYPOINT ["/tini", "--"]
-
 CMD [ "echo", "No default command" ]
 
-# Emulate an anonymous uid, similar to executing in an OpenShift environment
+# Emulate an anonymous uid
 USER 9999:0


### PR DESCRIPTION
Factor the dependencies that are specific to running the ray operator/autoscaler into a specific `ray-operator-ubi` image, and leave the core `ray-ubi` image smaller.

Additionally adds build args to parameterize ray and python, and adds a new `build.sh` script to run builds